### PR TITLE
Add DSFMT_SHLIB that will enable building of shared libraries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.dylib
+*.a
+*.so
+test-*

--- a/dSFMT.c
+++ b/dSFMT.c
@@ -32,13 +32,13 @@ static const int dsfmt_mexp = DSFMT_MEXP;
 inline static uint32_t ini_func1(uint32_t x);
 inline static uint32_t ini_func2(uint32_t x);
 inline static void gen_rand_array_c1o2(dsfmt_t *dsfmt, w128_t *array,
-				       int size);
+				       ptrdiff_t size);
 inline static void gen_rand_array_c0o1(dsfmt_t *dsfmt, w128_t *array,
-				       int size);
+				       ptrdiff_t size);
 inline static void gen_rand_array_o0c1(dsfmt_t *dsfmt, w128_t *array,
-				       int size);
+				       ptrdiff_t size);
 inline static void gen_rand_array_o0o1(dsfmt_t *dsfmt, w128_t *array,
-				       int size);
+				       ptrdiff_t size);
 inline static int idxof(int i);
 static void initial_mask(dsfmt_t *dsfmt);
 static void period_certification(dsfmt_t *dsfmt);
@@ -142,8 +142,8 @@ inline static void convert_o0o1(w128_t *w) {
  * @param size number of 128-bit pseudorandom numbers to be generated.
  */
 inline static void gen_rand_array_c1o2(dsfmt_t *dsfmt, w128_t *array,
-				       int size) {
-    int i, j;
+				       ptrdiff_t size) {
+    ptrdiff_t i, j;
     w128_t lung;
 
     lung = dsfmt->status[DSFMT_N];
@@ -180,8 +180,8 @@ inline static void gen_rand_array_c1o2(dsfmt_t *dsfmt, w128_t *array,
  * @param size number of 128-bit pseudorandom numbers to be generated.
  */
 inline static void gen_rand_array_c0o1(dsfmt_t *dsfmt, w128_t *array,
-				       int size) {
-    int i, j;
+				       ptrdiff_t size) {
+    ptrdiff_t i, j;
     w128_t lung;
 
     lung = dsfmt->status[DSFMT_N];
@@ -223,8 +223,8 @@ inline static void gen_rand_array_c0o1(dsfmt_t *dsfmt, w128_t *array,
  * @param size number of 128-bit pseudorandom numbers to be generated.
  */
 inline static void gen_rand_array_o0o1(dsfmt_t *dsfmt, w128_t *array,
-				       int size) {
-    int i, j;
+				       ptrdiff_t size) {
+    ptrdiff_t i, j;
     w128_t lung;
 
     lung = dsfmt->status[DSFMT_N];
@@ -266,8 +266,8 @@ inline static void gen_rand_array_o0o1(dsfmt_t *dsfmt, w128_t *array,
  * @param size number of 128-bit pseudorandom numbers to be generated.
  */
 inline static void gen_rand_array_o0c1(dsfmt_t *dsfmt, w128_t *array,
-				       int size) {
-    int i, j;
+				       ptrdiff_t size) {
+    ptrdiff_t i, j;
     w128_t lung;
 
     lung = dsfmt->status[DSFMT_N];
@@ -453,7 +453,7 @@ void dsfmt_gen_rand_all(dsfmt_t *dsfmt) {
  * memory. Mac OSX doesn't have these functions, but \b malloc of OSX
  * returns the pointer to the aligned memory block.
  */
-void dsfmt_fill_array_close1_open2(dsfmt_t *dsfmt, double array[], int size) {
+void dsfmt_fill_array_close1_open2(dsfmt_t *dsfmt, double array[], ptrdiff_t size) {
     assert(size % 2 == 0);
     assert(size >= DSFMT_N64);
     gen_rand_array_c1o2(dsfmt, (w128_t *)array, size / 2);
@@ -471,7 +471,7 @@ void dsfmt_fill_array_close1_open2(dsfmt_t *dsfmt, double array[], int size) {
  * @param size the number of pseudorandom numbers to be generated.
  * see also \sa fill_array_close1_open2()
  */
-void dsfmt_fill_array_open_close(dsfmt_t *dsfmt, double array[], int size) {
+void dsfmt_fill_array_open_close(dsfmt_t *dsfmt, double array[], ptrdiff_t size) {
     assert(size % 2 == 0);
     assert(size >= DSFMT_N64);
     gen_rand_array_o0c1(dsfmt, (w128_t *)array, size / 2);
@@ -489,7 +489,7 @@ void dsfmt_fill_array_open_close(dsfmt_t *dsfmt, double array[], int size) {
  * @param size the number of pseudorandom numbers to be generated.
  * see also \sa fill_array_close1_open2()
  */
-void dsfmt_fill_array_close_open(dsfmt_t *dsfmt, double array[], int size) {
+void dsfmt_fill_array_close_open(dsfmt_t *dsfmt, double array[], ptrdiff_t size) {
     assert(size % 2 == 0);
     assert(size >= DSFMT_N64);
     gen_rand_array_c0o1(dsfmt, (w128_t *)array, size / 2);
@@ -507,7 +507,7 @@ void dsfmt_fill_array_close_open(dsfmt_t *dsfmt, double array[], int size) {
  * @param size the number of pseudorandom numbers to be generated.
  * see also \sa fill_array_close1_open2()
  */
-void dsfmt_fill_array_open_open(dsfmt_t *dsfmt, double array[], int size) {
+void dsfmt_fill_array_open_open(dsfmt_t *dsfmt, double array[], ptrdiff_t size) {
     assert(size % 2 == 0);
     assert(size >= DSFMT_N64);
     gen_rand_array_o0o1(dsfmt, (w128_t *)array, size / 2);

--- a/dSFMT.h
+++ b/dSFMT.h
@@ -40,6 +40,7 @@ extern "C" {
 
 #include <stdio.h>
 #include <assert.h>
+#include <stddef.h>
 
 #if !defined(DSFMT_MEXP)
 #ifdef __GNUC__
@@ -180,26 +181,34 @@ extern dsfmt_t dsfmt_global_data;
 extern const int dsfmt_global_mexp;
 
 void dsfmt_gen_rand_all(dsfmt_t *dsfmt);
-void dsfmt_fill_array_open_close(dsfmt_t *dsfmt, double array[], int size);
-void dsfmt_fill_array_close_open(dsfmt_t *dsfmt, double array[], int size);
-void dsfmt_fill_array_open_open(dsfmt_t *dsfmt, double array[], int size);
-void dsfmt_fill_array_close1_open2(dsfmt_t *dsfmt, double array[], int size);
+void dsfmt_fill_array_open_close(dsfmt_t *dsfmt, double array[], ptrdiff_t size);
+void dsfmt_fill_array_close_open(dsfmt_t *dsfmt, double array[], ptrdiff_t size);
+void dsfmt_fill_array_open_open(dsfmt_t *dsfmt, double array[], ptrdiff_t size);
+void dsfmt_fill_array_close1_open2(dsfmt_t *dsfmt, double array[], ptrdiff_t size);
 void dsfmt_chk_init_gen_rand(dsfmt_t *dsfmt, uint32_t seed, int mexp);
 void dsfmt_chk_init_by_array(dsfmt_t *dsfmt, uint32_t init_key[],
                              int key_length, int mexp);
 const char *dsfmt_get_idstring(void);
 int dsfmt_get_min_array_size(void);
 
-#if defined(__GNUC__)
+#if defined(DSFMT_SHLIB)
+#  define DSFMT_PRE_INLINE
+#  define DSFMT_PRE_INLINE2
+#  define DSFMT_PST_INLINE
+#elif defined(__GNUC__)
 #  define DSFMT_PRE_INLINE inline static
+#  define DSFMT_PRE_INLINE2 inline static
 #  define DSFMT_PST_INLINE __attribute__((always_inline))
 #elif defined(_MSC_VER) && _MSC_VER >= 1200
 #  define DSFMT_PRE_INLINE __forceinline static
+#  define DSFMT_PRE_INLINE2 inline static
 #  define DSFMT_PST_INLINE
 #else
 #  define DSFMT_PRE_INLINE inline static
+#  define DSFMT_PRE_INLINE2 inline static
 #  define DSFMT_PST_INLINE
 #endif
+
 DSFMT_PRE_INLINE uint32_t dsfmt_genrand_uint32(dsfmt_t *dsfmt) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE double dsfmt_genrand_close1_open2(dsfmt_t *dsfmt)
     DSFMT_PST_INLINE;
@@ -214,13 +223,13 @@ DSFMT_PRE_INLINE double dsfmt_gv_genrand_close1_open2(void) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE double dsfmt_gv_genrand_close_open(void) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE double dsfmt_gv_genrand_open_close(void) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE double dsfmt_gv_genrand_open_open(void) DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void dsfmt_gv_fill_array_open_close(double array[], int size)
+DSFMT_PRE_INLINE void dsfmt_gv_fill_array_open_close(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void dsfmt_gv_fill_array_close_open(double array[], int size)
+DSFMT_PRE_INLINE void dsfmt_gv_fill_array_close_open(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void dsfmt_gv_fill_array_open_open(double array[], int size)
+DSFMT_PRE_INLINE void dsfmt_gv_fill_array_open_open(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void dsfmt_gv_fill_array_close1_open2(double array[], int size)
+DSFMT_PRE_INLINE void dsfmt_gv_fill_array_close1_open2(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE void dsfmt_gv_init_gen_rand(uint32_t seed) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE void dsfmt_gv_init_by_array(uint32_t init_key[],
@@ -238,7 +247,7 @@ DSFMT_PRE_INLINE void dsfmt_init_by_array(dsfmt_t *dsfmt, uint32_t init_key[],
  * @param dsfmt dsfmt internal state date
  * @return double precision floating point pseudorandom number
  */
-inline static uint32_t dsfmt_genrand_uint32(dsfmt_t *dsfmt) {
+DSFMT_PRE_INLINE2 uint32_t dsfmt_genrand_uint32(dsfmt_t *dsfmt) {
     uint32_t r;
     uint64_t *psfmt64 = &dsfmt->status[0].u[0];
 
@@ -259,7 +268,7 @@ inline static uint32_t dsfmt_genrand_uint32(dsfmt_t *dsfmt) {
  * @param dsfmt dsfmt internal state date
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_genrand_close1_open2(dsfmt_t *dsfmt) {
+DSFMT_PRE_INLINE2 double dsfmt_genrand_close1_open2(dsfmt_t *dsfmt) {
     double r;
     double *psfmt64 = &dsfmt->status[0].d[0];
 
@@ -278,7 +287,7 @@ inline static double dsfmt_genrand_close1_open2(dsfmt_t *dsfmt) {
  * before this function.  This function uses \b global variables.
  * @return double precision floating point pseudorandom number
  */
-inline static uint32_t dsfmt_gv_genrand_uint32(void) {
+DSFMT_PRE_INLINE2 uint32_t dsfmt_gv_genrand_uint32(void) {
     return dsfmt_genrand_uint32(&dsfmt_global_data);
 }
 
@@ -289,7 +298,7 @@ inline static uint32_t dsfmt_gv_genrand_uint32(void) {
  * before this function. This function uses \b global variables.
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_gv_genrand_close1_open2(void) {
+DSFMT_PRE_INLINE2 double dsfmt_gv_genrand_close1_open2(void) {
     return dsfmt_genrand_close1_open2(&dsfmt_global_data);
 }
 
@@ -301,7 +310,7 @@ inline static double dsfmt_gv_genrand_close1_open2(void) {
  * @param dsfmt dsfmt internal state date
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_genrand_close_open(dsfmt_t *dsfmt) {
+DSFMT_PRE_INLINE2 double dsfmt_genrand_close_open(dsfmt_t *dsfmt) {
     return dsfmt_genrand_close1_open2(dsfmt) - 1.0;
 }
 
@@ -312,7 +321,7 @@ inline static double dsfmt_genrand_close_open(dsfmt_t *dsfmt) {
  * before this function. This function uses \b global variables.
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_gv_genrand_close_open(void) {
+DSFMT_PRE_INLINE2 double dsfmt_gv_genrand_close_open(void) {
     return dsfmt_gv_genrand_close1_open2() - 1.0;
 }
 
@@ -324,7 +333,7 @@ inline static double dsfmt_gv_genrand_close_open(void) {
  * @param dsfmt dsfmt internal state date
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_genrand_open_close(dsfmt_t *dsfmt) {
+DSFMT_PRE_INLINE2 double dsfmt_genrand_open_close(dsfmt_t *dsfmt) {
     return 2.0 - dsfmt_genrand_close1_open2(dsfmt);
 }
 
@@ -335,7 +344,7 @@ inline static double dsfmt_genrand_open_close(dsfmt_t *dsfmt) {
  * before this function. This function uses \b global variables.
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_gv_genrand_open_close(void) {
+DSFMT_PRE_INLINE2 double dsfmt_gv_genrand_open_close(void) {
     return 2.0 - dsfmt_gv_genrand_close1_open2();
 }
 
@@ -347,7 +356,7 @@ inline static double dsfmt_gv_genrand_open_close(void) {
  * @param dsfmt dsfmt internal state date
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_genrand_open_open(dsfmt_t *dsfmt) {
+DSFMT_PRE_INLINE2 double dsfmt_genrand_open_open(dsfmt_t *dsfmt) {
     double *dsfmt64 = &dsfmt->status[0].d[0];
     union {
         double d;
@@ -370,7 +379,7 @@ inline static double dsfmt_genrand_open_open(dsfmt_t *dsfmt) {
  * before this function. This function uses \b global variables.
  * @return double precision floating point pseudorandom number
  */
-inline static double dsfmt_gv_genrand_open_open(void) {
+DSFMT_PRE_INLINE2 double dsfmt_gv_genrand_open_open(void) {
     return dsfmt_genrand_open_open(&dsfmt_global_data);
 }
 
@@ -385,7 +394,7 @@ inline static double dsfmt_gv_genrand_open_open(void) {
  * @param size the number of pseudorandom numbers to be generated.
  * see also \sa dsfmt_fill_array_close1_open2()
  */
-inline static void dsfmt_gv_fill_array_close1_open2(double array[], int size) {
+DSFMT_PRE_INLINE2 void dsfmt_gv_fill_array_close1_open2(double array[], ptrdiff_t size) {
     dsfmt_fill_array_close1_open2(&dsfmt_global_data, array, size);
 }
 
@@ -401,7 +410,7 @@ inline static void dsfmt_gv_fill_array_close1_open2(double array[], int size) {
  * see also \sa dsfmt_fill_array_close1_open2() and \sa
  * dsfmt_gv_fill_array_close1_open2()
  */
-inline static void dsfmt_gv_fill_array_open_close(double array[], int size) {
+DSFMT_PRE_INLINE2 void dsfmt_gv_fill_array_open_close(double array[], ptrdiff_t size) {
     dsfmt_fill_array_open_close(&dsfmt_global_data, array, size);
 }
 
@@ -417,7 +426,7 @@ inline static void dsfmt_gv_fill_array_open_close(double array[], int size) {
  * see also \sa dsfmt_fill_array_close1_open2() \sa
  * dsfmt_gv_fill_array_close1_open2()
  */
-inline static void dsfmt_gv_fill_array_close_open(double array[], int size) {
+DSFMT_PRE_INLINE2 void dsfmt_gv_fill_array_close_open(double array[], ptrdiff_t size) {
     dsfmt_fill_array_close_open(&dsfmt_global_data, array, size);
 }
 
@@ -433,7 +442,7 @@ inline static void dsfmt_gv_fill_array_close_open(double array[], int size) {
  * see also \sa dsfmt_fill_array_close1_open2() \sa
  * dsfmt_gv_fill_array_close1_open2()
  */
-inline static void dsfmt_gv_fill_array_open_open(double array[], int size) {
+DSFMT_PRE_INLINE2 void dsfmt_gv_fill_array_open_open(double array[], ptrdiff_t size) {
     dsfmt_fill_array_open_open(&dsfmt_global_data, array, size);
 }
 
@@ -443,7 +452,7 @@ inline static void dsfmt_gv_fill_array_open_open(double array[], int size) {
  * @param dsfmt dsfmt state vector.
  * @param seed a 32-bit integer used as the seed.
  */
-inline static void dsfmt_init_gen_rand(dsfmt_t *dsfmt, uint32_t seed) {
+DSFMT_PRE_INLINE2 void dsfmt_init_gen_rand(dsfmt_t *dsfmt, uint32_t seed) {
     dsfmt_chk_init_gen_rand(dsfmt, seed, DSFMT_MEXP);
 }
 
@@ -453,7 +462,7 @@ inline static void dsfmt_init_gen_rand(dsfmt_t *dsfmt, uint32_t seed) {
  * @param seed a 32-bit integer used as the seed.
  * see also \sa dsfmt_init_gen_rand()
  */
-inline static void dsfmt_gv_init_gen_rand(uint32_t seed) {
+DSFMT_PRE_INLINE2 void dsfmt_gv_init_gen_rand(uint32_t seed) {
     dsfmt_init_gen_rand(&dsfmt_global_data, seed);
 }
 
@@ -464,7 +473,7 @@ inline static void dsfmt_gv_init_gen_rand(uint32_t seed) {
  * @param init_key the array of 32-bit integers, used as a seed.
  * @param key_length the length of init_key.
  */
-inline static void dsfmt_init_by_array(dsfmt_t *dsfmt, uint32_t init_key[],
+DSFMT_PRE_INLINE2 void dsfmt_init_by_array(dsfmt_t *dsfmt, uint32_t init_key[],
                                        int key_length) {
     dsfmt_chk_init_by_array(dsfmt, init_key, key_length, DSFMT_MEXP);
 }
@@ -477,7 +486,7 @@ inline static void dsfmt_init_by_array(dsfmt_t *dsfmt, uint32_t init_key[],
  * @param key_length the length of init_key.
  * see also \sa dsfmt_init_by_array()
  */
-inline static void dsfmt_gv_init_by_array(uint32_t init_key[], int key_length) {
+DSFMT_PRE_INLINE2 void dsfmt_gv_init_by_array(uint32_t init_key[], int key_length) {
     dsfmt_init_by_array(&dsfmt_global_data, init_key, key_length);
 }
 
@@ -491,13 +500,13 @@ DSFMT_PRE_INLINE double genrand_close1_open2(void) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE double genrand_close_open(void) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE double genrand_open_close(void) DSFMT_PST_INLINE;
 DSFMT_PRE_INLINE double genrand_open_open(void) DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void fill_array_open_close(double array[], int size)
+DSFMT_PRE_INLINE void fill_array_open_close(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void fill_array_close_open(double array[], int size)
+DSFMT_PRE_INLINE void fill_array_close_open(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void fill_array_open_open(double array[], int size)
+DSFMT_PRE_INLINE void fill_array_open_open(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
-DSFMT_PRE_INLINE void fill_array_close1_open2(double array[], int size)
+DSFMT_PRE_INLINE void fill_array_close1_open2(double array[], ptrdiff_t size)
     DSFMT_PST_INLINE;
 
 /**
@@ -505,7 +514,7 @@ DSFMT_PRE_INLINE void fill_array_close1_open2(double array[], int size)
  * @return id string.
  * see also \sa dsfmt_get_idstring()
  */
-inline static const char *get_idstring(void) {
+DSFMT_PRE_INLINE2 const char *get_idstring(void) {
     return dsfmt_get_idstring();
 }
 
@@ -514,7 +523,7 @@ inline static const char *get_idstring(void) {
  * @return minimum size of array used for fill_array functions.
  * see also \sa dsfmt_get_min_array_size()
  */
-inline static int get_min_array_size(void) {
+DSFMT_PRE_INLINE2 int get_min_array_size(void) {
     return dsfmt_get_min_array_size();
 }
 
@@ -523,7 +532,7 @@ inline static int get_min_array_size(void) {
  * @param seed a 32-bit integer used as the seed.
  * see also \sa dsfmt_gv_init_gen_rand(), \sa dsfmt_init_gen_rand().
  */
-inline static void init_gen_rand(uint32_t seed) {
+DSFMT_PRE_INLINE2 void init_gen_rand(uint32_t seed) {
     dsfmt_gv_init_gen_rand(seed);
 }
 
@@ -533,7 +542,7 @@ inline static void init_gen_rand(uint32_t seed) {
  * @param key_length the length of init_key.
  * see also \sa dsfmt_gv_init_by_array(), \sa dsfmt_init_by_array().
  */
-inline static void init_by_array(uint32_t init_key[], int key_length) {
+DSFMT_PRE_INLINE2 void init_by_array(uint32_t init_key[], int key_length) {
     dsfmt_gv_init_by_array(init_key, key_length);
 }
 
@@ -543,7 +552,7 @@ inline static void init_by_array(uint32_t init_key[], int key_length) {
  * see also \sa dsfmt_genrand_close1_open2() \sa
  * dsfmt_gv_genrand_close1_open2()
  */
-inline static double genrand_close1_open2(void) {
+DSFMT_PRE_INLINE2 double genrand_close1_open2(void) {
     return dsfmt_gv_genrand_close1_open2();
 }
 
@@ -553,7 +562,7 @@ inline static double genrand_close1_open2(void) {
  * see also \sa dsfmt_genrand_close_open() \sa
  * dsfmt_gv_genrand_close_open()
  */
-inline static double genrand_close_open(void) {
+DSFMT_PRE_INLINE2 double genrand_close_open(void) {
     return dsfmt_gv_genrand_close_open();
 }
 
@@ -563,7 +572,7 @@ inline static double genrand_close_open(void) {
  * see also \sa dsfmt_genrand_open_close() \sa
  * dsfmt_gv_genrand_open_close()
  */
-inline static double genrand_open_close(void) {
+DSFMT_PRE_INLINE2 double genrand_open_close(void) {
     return dsfmt_gv_genrand_open_close();
 }
 
@@ -573,7 +582,7 @@ inline static double genrand_open_close(void) {
  * see also \sa dsfmt_genrand_open_open() \sa
  * dsfmt_gv_genrand_open_open()
  */
-inline static double genrand_open_open(void) {
+DSFMT_PRE_INLINE2 double genrand_open_open(void) {
     return dsfmt_gv_genrand_open_open();
 }
 
@@ -586,7 +595,7 @@ inline static double genrand_open_open(void) {
  * dsfmt_fill_array_close1_open2(), \sa
  * dsfmt_gv_fill_array_close1_open2()
  */
-inline static void fill_array_open_close(double array[], int size) {
+DSFMT_PRE_INLINE2 void fill_array_open_close(double array[], ptrdiff_t size) {
     dsfmt_gv_fill_array_open_close(array, size);
 }
 
@@ -599,7 +608,7 @@ inline static void fill_array_open_close(double array[], int size) {
  * dsfmt_fill_array_close1_open2(), \sa
  * dsfmt_gv_fill_array_close1_open2()
  */
-inline static void fill_array_close_open(double array[], int size) {
+DSFMT_PRE_INLINE2 void fill_array_close_open(double array[], ptrdiff_t size) {
     dsfmt_gv_fill_array_close_open(array, size);
 }
 
@@ -612,7 +621,7 @@ inline static void fill_array_close_open(double array[], int size) {
  * dsfmt_fill_array_close1_open2(), \sa
  * dsfmt_gv_fill_array_close1_open2()
  */
-inline static void fill_array_open_open(double array[], int size) {
+DSFMT_PRE_INLINE2 void fill_array_open_open(double array[], ptrdiff_t size) {
     dsfmt_gv_fill_array_open_open(array, size);
 }
 
@@ -624,7 +633,7 @@ inline static void fill_array_open_open(double array[], int size) {
  * see also \sa dsfmt_fill_array_close1_open2(), \sa
  * dsfmt_gv_fill_array_close1_open2()
  */
-inline static void fill_array_close1_open2(double array[], int size) {
+DSFMT_PRE_INLINE2 void fill_array_close1_open2(double array[], ptrdiff_t size) {
     dsfmt_gv_fill_array_close1_open2(array, size);
 }
 #endif /* DSFMT_DO_NOT_USE_OLD_NAMES */


### PR DESCRIPTION
Fix #2.

When `-DDSFMT_SHLIB` is passed to the C compiler, inlining is disabled.  Incorporates #3 as well - using `ptrdiff_t`.

Example:
```
➜  dSFMT git:(vs/inline) gcc -O3 -finline-functions -fomit-frame-pointer -DNDEBUG -fno-strict-aliasing --param max-inline-insns-single=1800 -Wmissing-prototypes -Wall  -std=c99 -DDSFMT_MEXP=19937 -DDSFMT_SHLIB -shared -fPIC dSFMT.c -o libdSFMT.dylib
clang: warning: argument unused during compilation: '--param max-inline-insns-single=1800' [-Wunused-command-line-argument]
➜  dSFMT git:(vs/inline) otool -L libdSFMT.dylib
libdSFMT.dylib:
	libdSFMT.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
➜  dSFMT git:(vs/inline) ls -l *.dylib          
-rwxr-xr-x  1 viral  staff  52008 Oct 10 14:24 libdSFMT.dylib
```